### PR TITLE
feat: add Terraform module for Lambda worker invoke IAM role

### DIFF
--- a/modules/serverless-workers/aws/lambda/README.md
+++ b/modules/serverless-workers/aws/lambda/README.md
@@ -1,0 +1,54 @@
+# Terraform AWS IAM Role Module For Serverless Workers
+
+This module facilitates the configuration of an AWS IAM role, an essential step in the overall setup for Serverless Workers. The module provides support for the following functionalities:
+
+- Creation of an IAM role in the customer's AWS account.
+- Establishing trust with the Temporal Cloud AWS accounts via a cross-account assume-role policy, secured with an External ID.
+- Granting `lambda:InvokeFunction` and `lambda:GetFunction` permissions on the specified Lambda functions.
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.5.7
+- AWS provider ~> 5.0
+- AWS credentials configured for the account where the Lambda functions are deployed
+- The `temporal_cloud_principals` values provided by Temporal Cloud during account setup
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "serverless-worker-lambda" {
+  source = "terraform-modules/modules/serverless-workers/aws/lambda"
+
+  external_id               = "<external-id>"
+  temporal_cloud_principals = "<provided by Temporal Cloud>"
+
+  lambda_function_arns = [
+    "arn:aws:lambda:us-east-1:123456789012:function:my-worker-1",
+    "arn:aws:lambda:us-east-1:123456789012:function:my-worker-2",
+  ]
+
+  # Optional: override the default role name
+  # role_name = "Temporal-Cloud-Serverless-Worker"
+}
+```
+
+Once applied, provide the `role_arn` output value to Temporal Cloud to complete the setup.
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `external_id` | External ID provided by Temporal Cloud. Must be 5–45 characters: alphanumeric and `_+=,.@-`. | `string` | — | yes |
+| `temporal_cloud_principals` | Temporal Cloud AWS IAM role ARNs permitted to assume this role. Provided by Temporal Cloud. | `list(string)` | — | yes |
+| `lambda_function_arns` | Lambda function ARNs that Temporal Cloud is permitted to invoke. | `list(string)` | — | yes |
+| `role_name` | Name of the IAM role to create. | `string` | `Temporal-Cloud-Serverless-Worker` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `role_arn` | ARN of the created IAM role. Provide this to Temporal Cloud. |
+| `role_name` | Name of the created IAM role. |
+| `lambda_function_arns` | Lambda function ARNs that Temporal Cloud is permitted to invoke. |

--- a/modules/serverless-workers/aws/lambda/main.tf
+++ b/modules/serverless-workers/aws/lambda/main.tf
@@ -1,0 +1,39 @@
+resource "aws_iam_role" "this" {
+  name                 = var.role_name
+  description          = "The role Temporal Cloud uses to invoke Lambda functions for Serverless Workers"
+  max_session_duration = 3600
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          AWS = var.temporal_cloud_principals
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "sts:ExternalId" = var.external_id
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_invoke" {
+  name = "Temporal-Cloud-Lambda-Invoke-Permissions"
+  role = aws_iam_role.this.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["lambda:InvokeFunction", "lambda:GetFunction"]
+        Resource = var.lambda_function_arns
+      }
+    ]
+  })
+}

--- a/modules/serverless-workers/aws/lambda/outputs.tf
+++ b/modules/serverless-workers/aws/lambda/outputs.tf
@@ -1,0 +1,14 @@
+output "role_arn" {
+  description = "ARN of the IAM role created for Temporal Cloud. Provide this value to Temporal Cloud to complete the setup."
+  value       = aws_iam_role.this.arn
+}
+
+output "role_name" {
+  description = "Name of the IAM role."
+  value       = aws_iam_role.this.name
+}
+
+output "lambda_function_arns" {
+  description = "Lambda function ARNs that Temporal Cloud is permitted to invoke."
+  value       = var.lambda_function_arns
+}

--- a/modules/serverless-workers/aws/lambda/variables.tf
+++ b/modules/serverless-workers/aws/lambda/variables.tf
@@ -1,0 +1,35 @@
+variable "external_id" {
+  description = "The External ID for cross-account role assumption."
+  type        = string
+
+  validation {
+    condition     = length(var.external_id) >= 5 && length(var.external_id) <= 45 && can(regex("^[a-zA-Z0-9_+=,.@-]+$", var.external_id))
+    error_message = "external_id must be 5-45 characters and contain only alphanumeric characters and _+=,.@- symbols."
+  }
+}
+
+variable "temporal_cloud_principals" {
+  description = "List of Temporal Cloud AWS IAM role ARNs permitted to assume this role. Provided by Temporal Cloud."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.temporal_cloud_principals) > 0
+    error_message = "At least one Temporal Cloud principal ARN must be provided."
+  }
+}
+
+variable "lambda_function_arns" {
+  description = "List of Lambda function ARNs that Temporal Cloud is permitted to invoke."
+  type        = list(string)
+
+  validation {
+    condition     = length(var.lambda_function_arns) > 0
+    error_message = "At least one Lambda function ARN must be provided."
+  }
+}
+
+variable "role_name" {
+  description = "Name of the IAM role to create."
+  type        = string
+  default     = "Temporal-Cloud-Serverless-Worker"
+}

--- a/modules/serverless-workers/aws/lambda/versions.tf
+++ b/modules/serverless-workers/aws/lambda/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
## What Changed?
Add Terraform module as an alternative to the existing CloudFormation template for creating the IAM role that allows Temporal Cloud to invoke Lambda-based Serverless Workers.

## Why?
Provides a Terraform-native option for customers who manage AWS infrastructure with Terraform rather than CloudFormation.

## How was this tested?
- Used `terraform plan` and `terraform apply` to create IAM role and trust relationships in test AWS account