### PR TITLE
COM-113: New module for Cloud Run serverless workers

### DIFF
--- a/modules/serverless-workers/gcp/cloud-run/README.md
+++ b/modules/serverless-workers/gcp/cloud-run/README.md
@@ -1,0 +1,58 @@
+# Terraform GCP Service Account Module For Cloud Run Serverless Workers
+
+This module facilitates the configuration of a GCP service account, an essential step in the overall setup for Serverless Workers on Cloud Run. The module provides support for the following functionalities:
+
+- Creation of an invoker service account in the customer's GCP project.
+- Establishing trust with the Temporal Cloud service accounts by granting them `roles/iam.serviceAccountTokenCreator` on the invoker, so the Temporal Cloud impersonation chain can act as it.
+- Granting the invoker the Cloud Run permissions needed to read and scale the worker pool (at minimum `run.workerPools.get` and `run.workerPools.update`) through `deploy_roles` (default `roles/run.developer`, which includes both permissions).
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) >= 1.5.7
+- Google provider ~> 4.0
+- GCP credentials configured for the project where the Cloud Run worker pool is deployed
+- The `impersonator_service_account_emails` values provided by Temporal Cloud
+
+## Usage
+
+Basic usage of this module is as follows:
+
+```hcl
+module "serverless-worker-cloud-run" {
+  source = "terraform-modules/modules/serverless-workers/gcp/cloud-run"
+
+  project_id         = "my-worker-project"
+  invoker_account_id = "temporal-serverless-worker"
+
+  impersonator_service_account_emails = [
+    "<provided by Temporal Cloud>",
+  ]
+
+  # Optional: override the default Cloud Run roles
+  # deploy_roles = ["roles/run.developer"]
+}
+```
+
+Once applied, provide the `invoker_email` output value to Temporal Cloud to complete the setup.
+
+> **Note:** Temporal Cloud only reads and scales the worker pool as the invoker. If you replace the default `deploy_roles` with a custom (least-privilege) role, that role must grant at least the following permissions:
+>
+> - `run.workerPools.get`
+> - `run.workerPools.update`
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|----------|
+| `project_id` | GCP project that hosts the Cloud Run worker pool and the invoker service account. | `string` | — | yes |
+| `invoker_account_id` | Account id of the invoker service account that creates, updates, and scales the worker pool. | `string` | — | yes |
+| `impersonator_service_account_emails` | Temporal Cloud service account emails permitted to impersonate the invoker. Provided by Temporal Cloud. | `set(string)` | — | yes |
+| `invoker_display_name` | Display name for the invoker service account. | `string` | `Temporal Serverless Worker Pool Invoker` | no |
+| `deploy_roles` | Project-level Cloud Run roles granted to the invoker. Any role used must include at least `run.workerPools.get` and `run.workerPools.update`. | `set(string)` | `["roles/run.developer"]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| `invoker_email` | Email of the created invoker service account. Provide this to Temporal Cloud. |
+| `invoker_id` | Fully-qualified resource id of the created invoker service account. |

--- a/modules/serverless-workers/gcp/cloud-run/main.tf
+++ b/modules/serverless-workers/gcp/cloud-run/main.tf
@@ -1,0 +1,25 @@
+# Invoker identity: the terminal SA of the Temporal serverless workers' impersonation
+# chain that reads and scales the Cloud Run worker pool. It never runs the pool,
+# so runtime power stays off this identity.
+resource "google_service_account" "invoker" {
+  project      = var.project_id
+  account_id   = var.invoker_account_id
+  display_name = var.invoker_display_name
+}
+
+# Cloud Run permissions needed to read (get) and scale (update) the worker pool.
+resource "google_project_iam_member" "deploy_roles" {
+  for_each = var.deploy_roles
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.invoker.email}"
+}
+
+# Inbound trust: the prior hops in the chain mint tokens to become the invoker.
+# This is the last hop of the impersonation chain.
+resource "google_service_account_iam_member" "impersonators" {
+  for_each           = var.impersonator_service_account_emails
+  service_account_id = google_service_account.invoker.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${each.value}"
+}

--- a/modules/serverless-workers/gcp/cloud-run/outputs.tf
+++ b/modules/serverless-workers/gcp/cloud-run/outputs.tf
@@ -1,0 +1,9 @@
+output "invoker_email" {
+  description = "Email of the invoker service account (the terminal identity of the Temporal serverless workers impersonation chain)"
+  value       = google_service_account.invoker.email
+}
+
+output "invoker_id" {
+  description = "Fully-qualified resource id of the invoker service account"
+  value       = google_service_account.invoker.name
+}

--- a/modules/serverless-workers/gcp/cloud-run/variables.tf
+++ b/modules/serverless-workers/gcp/cloud-run/variables.tf
@@ -1,0 +1,26 @@
+variable "project_id" {
+  description = "The GCP project that hosts the Cloud Run worker pool and the invoker service account"
+  type        = string
+}
+
+variable "invoker_account_id" {
+  description = "Account id of the invoker service account that reads and scales the worker pool (terminal identity of the Temporal serverless workers impersonation chain)"
+  type        = string
+}
+
+variable "invoker_display_name" {
+  description = "Display name for the invoker service account"
+  type        = string
+  default     = "Temporal Serverless Worker Pool Invoker"
+}
+
+variable "impersonator_service_account_emails" {
+  description = "Emails of the upstream service accounts allowed to impersonate the invoker (the prior hops in the Temporal serverless workers impersonation chain). Each is granted token-creator on the invoker"
+  type        = set(string)
+}
+
+variable "deploy_roles" {
+  description = "Project-level Cloud Run roles granted to the invoker. Any role used must include at least run.workerPools.get and run.workerPools.update. Defaults to roles/run.developer, which includes both"
+  type        = set(string)
+  default     = ["roles/run.developer"]
+}

--- a/modules/serverless-workers/gcp/cloud-run/versions.tf
+++ b/modules/serverless-workers/gcp/cloud-run/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+}


### PR DESCRIPTION

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Add Terraform module for creating GCP service account for Cloud Run serverless workers.

## Why?
<!-- Tell your future self why have you made these changes -->
Provide a Terraform native for customers to create the service account used for invoking GCP Cloud Run workers.
## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->
[COM-113](https://temporalio.atlassian.net/browse/COM-113)

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Terraform plan/apply to a sandbox GCP project
```
  terraform apply

  Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
    + create

  Terraform will perform the following actions:

  # module.invoker.google_project_iam_member.deploy_roles["roles/run.developer"] will be created
  + resource "google_project_iam_member" "deploy_roles" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = (known after apply)
      + project = "compute-team-sandbox"
      + role    = "roles/run.developer"
    }

  # module.invoker.google_service_account.invoker will be created
  + resource "google_service_account" "invoker" {
      + account_id   = "temporal-serverless-worker"
      + disabled     = false
      + display_name = "Temporal Serverless Worker Pool Invoker"
      + email        = (known after apply)
      + id           = (known after apply)
      + member       = (known after apply)
      + name         = (known after apply)
      + project      = "compute-team-sandbox"
      + unique_id    = (known after apply)
    }

  # module.invoker.google_service_account_iam_member.impersonators["serverless-global-sa@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"] will be created
  + resource "google_service_account_iam_member" "impersonators" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:serverless-global-sa@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = (known after apply)
    }

  # module.invoker.google_service_account_iam_member.impersonators["serverless-global-sa@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"] will be created
  + resource "google_service_account_iam_member" "impersonators" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:serverless-global-sa@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + invoker_email = (known after apply)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

module.invoker.google_service_account.invoker: Creating...
module.invoker.google_service_account.invoker: Creation complete after 6s [id=projects/compute-team-sandbox/serviceAccounts/temporal-serverless-worker@compute-team-sandbox.iam.gserviceaccount.com]
module.invoker.google_project_iam_member.deploy_roles["roles/run.developer"]: Creating...
module.invoker.google_service_account_iam_member.impersonators["serverless-global-sa@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"]: Creating...
module.invoker.google_service_account_iam_member.impersonators["serverless-global-sa@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"]: Creating...
module.invoker.google_project_iam_member.deploy_roles["roles/run.developer"]: Creation complete after 7s [id=compute-team-sandbox/roles/run.developer/serviceAccount:temporal-serverless-worker@compute-team-sandbox.iam.gserviceaccount.com]
module.invoker.google_service_account_iam_member.impersonators["serverless-global-sa@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"]: Creation complete after 8s [id=projects/compute-team-sandbox/serviceAccounts/temporal-serverless-worker@compute-team-sandbox.iam.gserviceaccount.com/roles/iam.serviceAccountTokenCreator/serviceAccount:serverless-global-sa@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com]
module.invoker.google_service_account_iam_member.impersonators["serverless-global-sa@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"]: Creation complete after 8s [id=projects/compute-team-sandbox/serviceAccounts/temporal-serverless-worker@compute-team-sandbox.iam.gserviceaccount.com/roles/iam.serviceAccountTokenCreator/serviceAccount:serverless-global-sa@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

invoker_email = "temporal-serverless-worker@compute-team-sandbox.iam.gserviceaccount.com"
```
Validated the newly created service account has the correct role assignment
```
❯ gcloud projects get-iam-policy compute-team-sandbox \                                                                                                                
    --flatten="bindings[].members" \
    --filter="bindings.members:temporal-serverless-worker@compute-team-sandbox.iam.gserviceaccount.com" --format="table(bindings.role)"
ROLE
roles/run.developer
```

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->


[COM-113]: https://temporalio.atlassian.net/browse/COM-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ