### PR TITLE
COM-113: Cloud Run worker module — attach a runner service account via actAs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
 *       @temporalio/saas
-*       @temporalio/compute

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @temporalio/saas
+*       @temporalio/compute

--- a/modules/serverless-workers/gcp/cloud-run/README.md
+++ b/modules/serverless-workers/gcp/cloud-run/README.md
@@ -5,6 +5,7 @@ This module facilitates the configuration of a GCP service account, an essential
 - Creation of an invoker service account in the customer's GCP project.
 - Establishing trust with the Temporal Cloud service accounts by granting them `roles/iam.serviceAccountTokenCreator` on the invoker, so the Temporal Cloud impersonation chain can act as it.
 - Granting the invoker the Cloud Run permissions needed to read and scale the worker pool (at minimum `run.workerPools.get` and `run.workerPools.update`) through `deploy_roles` (default `roles/run.developer`, which includes both permissions).
+- Granting the invoker `roles/iam.serviceAccountUser` (actAs) on the runner service account the worker pool runs as, so it can attach that identity to the pool. The runner is caller-provided via `runner_service_account_email`, or the project's default Compute Engine service account when unset. This module does not create the runner or grant it workload roles.
 
 ## Prerequisites
 
@@ -30,15 +31,21 @@ module "serverless-worker-cloud-run" {
 
   # Optional: override the default Cloud Run roles
   # deploy_roles = ["roles/run.developer"]
+
+  # Optional: service account the worker pool runs as. Defaults to the project's
+  # default Compute Engine service account when unset.
+  # runner_service_account_email = "my-runner@my-worker-project.iam.gserviceaccount.com"
 }
 ```
 
-Once applied, provide the `invoker_email` output value to Temporal Cloud to complete the setup.
+Once applied, provide the `invoker_email` output value to Temporal Cloud to complete the setup, and set `runner_service_account_email` (output) as the worker pool's service identity (`spec.template.serviceAccount`).
 
 > **Note:** Temporal Cloud only reads and scales the worker pool as the invoker. If you replace the default `deploy_roles` with a custom (least-privilege) role, that role must grant at least the following permissions:
 >
 > - `run.workerPools.get`
 > - `run.workerPools.update`
+
+> **Warning:** Leaving `runner_service_account_email` unset grants the invoker `actAs` on the project's **default Compute Engine service account**. That account holds the `roles/editor` primary role by default, so the invoker can attach a highly-privileged identity to the worker pool — a compromised invoker or pool would inherit project-wide Editor. For least privilege, pass a dedicated runner service account scoped to only the workload roles the pool needs (e.g. `roles/secretmanager.secretAccessor`).
 
 ## Inputs
 
@@ -49,6 +56,7 @@ Once applied, provide the `invoker_email` output value to Temporal Cloud to comp
 | `impersonator_service_account_emails` | Temporal Cloud service account emails permitted to impersonate the invoker. Provided by Temporal Cloud. | `set(string)` | — | yes |
 | `invoker_display_name` | Display name for the invoker service account. | `string` | `Temporal Serverless Worker Pool Invoker` | no |
 | `deploy_roles` | Project-level Cloud Run roles granted to the invoker. Any role used must include at least `run.workerPools.get` and `run.workerPools.update`. | `set(string)` | `["roles/run.developer"]` | no |
+| `runner_service_account_email` | Email of the service account the worker pool runs as. The invoker is granted actAs on it. Empty uses the project's default Compute Engine service account. | `string` | `""` | no |
 
 ## Outputs
 
@@ -56,3 +64,4 @@ Once applied, provide the `invoker_email` output value to Temporal Cloud to comp
 |------|-------------|
 | `invoker_email` | Email of the created invoker service account. Provide this to Temporal Cloud. |
 | `invoker_id` | Fully-qualified resource id of the created invoker service account. |
+| `runner_service_account_email` | Email of the service account the worker pool runs as. Set as the pool's `spec.template.serviceAccount`. |

--- a/modules/serverless-workers/gcp/cloud-run/main.tf
+++ b/modules/serverless-workers/gcp/cloud-run/main.tf
@@ -23,3 +23,27 @@ resource "google_service_account_iam_member" "impersonators" {
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${each.value}"
 }
+
+# Used to resolve the project's default Compute Engine service account, which
+# Cloud Run worker pools run as when no runner is specified.
+data "google_project" "this" {
+  project_id = var.project_id
+}
+
+# Runtime identity the worker pool runs as. Caller-provided when set; otherwise
+# the project default Compute Engine service account that Cloud Run uses by
+# default. This module never creates the runner (see actAs binding below).
+locals {
+  runner_service_account_email = coalesce(
+    var.runner_service_account_email,
+    "${data.google_project.this.number}-compute@developer.gserviceaccount.com",
+  )
+}
+
+# The invoker needs actAs on the runner to attach it as the worker pool's
+# service identity on CreateWorkerPool / UpdateWorkerPool.
+resource "google_service_account_iam_member" "invoker_act_as_runner" {
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${local.runner_service_account_email}"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.invoker.email}"
+}

--- a/modules/serverless-workers/gcp/cloud-run/outputs.tf
+++ b/modules/serverless-workers/gcp/cloud-run/outputs.tf
@@ -7,3 +7,8 @@ output "invoker_id" {
   description = "Fully-qualified resource id of the invoker service account"
   value       = google_service_account.invoker.name
 }
+
+output "runner_service_account_email" {
+  description = "Email of the service account the worker pool runs as (the caller-provided one, or the project default Compute Engine SA when unset). Set this as the worker pool's service_account (spec.template.serviceAccount)"
+  value       = local.runner_service_account_email
+}

--- a/modules/serverless-workers/gcp/cloud-run/variables.tf
+++ b/modules/serverless-workers/gcp/cloud-run/variables.tf
@@ -24,3 +24,9 @@ variable "deploy_roles" {
   type        = set(string)
   default     = ["roles/run.developer"]
 }
+
+variable "runner_service_account_email" {
+  description = "Email of the service account the Cloud Run worker pool runs as. Leave empty to use the project's default Compute Engine service account, which Cloud Run worker pools use by default. The invoker is granted actAs on this account so it can attach it as the pool's service identity. This module does not create the runner or grant it any workload roles"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
## What was changed                                                                                                                                                   
                                                                                                                                                                       
Adds the ability to specify the service account the Cloud Run worker pool runs as to the serverless-workers/gcp/cloud-run module, and grants the invoker the `actAs` needed to attach it.                                                                                                                                                 
                                                                                                                                                                       
  - New optional input runner_service_account_email.                                                                                                                   
    - Set → the pool runs as that (bring-your-own) SA.                                                                                                                 
    - Unset → falls back to the project's default Compute Engine SA (<project-number>-compute@developer.gserviceaccount.com), which Cloud Run worker pools use by      
  default.                                                                                                                                                             
  - New google_service_account_iam_member.invoker_act_as_runner binding grants the invoker roles/iam.serviceAccountUser on the runner, so it can attach that identity  
  on CreateWorkerPool / UpdateWorkerPool.                                                                                                                              
  - New output runner_service_account_email — set this as the pool's spec.template.serviceAccount.                                                                     
  - Adds @temporalio/compute to CODEOWNERS.                                                                                                                            
                                                                                                                                                                       
The module intentionally does not create the runner or grant it workload roles — it only wires the actAs attachment. Runner provisioning/roles stay with the caller.
                                                                                                                                                                       
## Why                                                                                                                                                                  
                                                                                                                                                                       
WCI's impersonation chain terminates at the invoker (deploy identity); the runner is a separate least-privilege identity the pool executes as. This lets callers  point the pool at a scoped runtime SA instead of collapsing deploy + runtime power onto one account.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Invoked the module against a sandbox project, here is the output
```
gcp/cloud-run/test on  COM-113-fix [!?] via 💠 default took 2s 
❯ terraform plan -out=tfplan
module.m.data.google_project.this: Reading...
module.m.data.google_project.this: Read complete after 1s [id=projects/compute-team-sandbox]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.m.google_project_iam_member.deploy_roles["roles/run.developer"] will be created
  + resource "google_project_iam_member" "deploy_roles" {
      + etag    = (known after apply)
      + id      = (known after apply)
      + member  = (known after apply)
      + project = "compute-team-sandbox"
      + role    = "roles/run.developer"
    }

  # module.m.google_service_account.invoker will be created
  + resource "google_service_account" "invoker" {
      + account_id   = "george-test-invoker"
      + disabled     = false
      + display_name = "Temporal Serverless Worker Pool Invoker"
      + email        = (known after apply)
      + id           = (known after apply)
      + member       = (known after apply)
      + name         = (known after apply)
      + project      = "compute-team-sandbox"
      + unique_id    = (known after apply)
    }

  # module.m.google_service_account_iam_member.impersonators["serverless-temporal-dev@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"] will be created
  + resource "google_service_account_iam_member" "impersonators" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:serverless-temporal-dev@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = (known after apply)
    }

  # module.m.google_service_account_iam_member.impersonators["serverless-temporal-dev@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"] will be created
  + resource "google_service_account_iam_member" "impersonators" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = "serviceAccount:serverless-temporal-dev@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"
      + role               = "roles/iam.serviceAccountTokenCreator"
      + service_account_id = (known after apply)
    }

  # module.m.google_service_account_iam_member.invoker_act_as_runner will be created
  + resource "google_service_account_iam_member" "invoker_act_as_runner" {
      + etag               = (known after apply)
      + id                 = (known after apply)
      + member             = (known after apply)
      + role               = "roles/iam.serviceAccountUser"
      + service_account_id = "projects/compute-team-sandbox/serviceAccounts/wci-invocation-sa@compute-team-sandbox.iam.gserviceaccount.com"
    }

Plan: 5 to add, 0 to change, 0 to destroy.

────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────

Saved the plan to: tfplan

To perform exactly these actions, run the following command to apply:
    terraform apply "tfplan"

gcp/cloud-run/test on  COM-113-fix [!?] via 💠 default 
❯ terraform apply tfplan 
module.m.google_service_account.invoker: Creating...
module.m.google_service_account.invoker: Creation complete after 2s [id=projects/compute-team-sandbox/serviceAccounts/george-test-invoker@compute-team-sandbox.iam.gserviceaccount.com]
module.m.google_project_iam_member.deploy_roles["roles/run.developer"]: Creating...
module.m.google_service_account_iam_member.impersonators["serverless-temporal-dev@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"]: Creating...
module.m.google_service_account_iam_member.invoker_act_as_runner: Creating...
module.m.google_service_account_iam_member.impersonators["serverless-temporal-dev@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"]: Creating...
module.m.google_service_account_iam_member.invoker_act_as_runner: Creation complete after 4s [id=projects/compute-team-sandbox/serviceAccounts/wci-invocation-sa@compute-team-sandbox.iam.gserviceaccount.com/roles/iam.serviceAccountUser/serviceAccount:george-test-invoker@compute-team-sandbox.iam.gserviceaccount.com]
module.m.google_project_iam_member.deploy_roles["roles/run.developer"]: Creation complete after 8s [id=compute-team-sandbox/roles/run.developer/serviceAccount:george-test-invoker@compute-team-sandbox.iam.gserviceaccount.com]
module.m.google_service_account_iam_member.impersonators["serverless-temporal-dev@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com"]: Creation complete after 8s [id=projects/compute-team-sandbox/serviceAccounts/george-test-invoker@compute-team-sandbox.iam.gserviceaccount.com/roles/iam.serviceAccountTokenCreator/serviceAccount:serverless-temporal-dev@test-zt5hvyyfbyfb2tsew2k3fpe5h.iam.gserviceaccount.com]
module.m.google_service_account_iam_member.impersonators["serverless-temporal-dev@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com"]: Creation complete after 8s [id=projects/compute-team-sandbox/serviceAccounts/george-test-invoker@compute-team-sandbox.iam.gserviceaccount.com/roles/iam.serviceAccountTokenCreator/serviceAccount:serverless-temporal-dev@test-3gd87drvpffdafs45kgqqsxfu.iam.gserviceaccount.com]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
```
3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
